### PR TITLE
added quotes to auth object keys where missing

### DIFF
--- a/lessons/11-receiving-json/index.py
+++ b/lessons/11-receiving-json/index.py
@@ -2,8 +2,8 @@ import skyciv
 
 api_object = {
     "auth": {
-        username: 'YOUR_SKYCIV_USERNAME',
-        key: 'YOUR_SKYCIV_API_KEY',
+        "username": 'YOUR_SKYCIV_USERNAME',
+        "key": 'YOUR_SKYCIV_API_KEY',
     },
     "functions": [
         {

--- a/lessons/16-making-the-http-request/index.py
+++ b/lessons/16-making-the-http-request/index.py
@@ -3,8 +3,8 @@ import skyciv
 # ========== FROM PREVIOUS LESSON ==============================================================
 # Create auth object
 auth = {
-    username: 'YOUR_SKYCIV_USERNAME',
-    key: 'YOUR_SKYCIV_API_KEY',
+    "username": 'YOUR_SKYCIV_USERNAME',
+    "key": 'YOUR_SKYCIV_API_KEY',
 }
 
 # Create options object - this is the default values so you could instead omit the entire object

--- a/lessons/17-interpreting-the-response/index.py
+++ b/lessons/17-interpreting-the-response/index.py
@@ -3,8 +3,8 @@ import skyciv
 # ========== FROM PREVIOUS LESSON ==============================================================
 # Create auth object
 auth = {
-    username: 'YOUR_SKYCIV_USERNAME',
-    key: 'YOUR_SKYCIV_API_KEY',
+    "username": 'YOUR_SKYCIV_USERNAME',
+    "key": 'YOUR_SKYCIV_API_KEY',
 }
 
 # Create options object - this is the default values so you could instead omit the entire object


### PR DESCRIPTION
Python files in lessons 11, 16, and 17 had the auth object keys without quotes.